### PR TITLE
added auto profile support

### DIFF
--- a/auto-ryzenadj.conf.example2
+++ b/auto-ryzenadj.conf.example2
@@ -1,0 +1,70 @@
+# the default config file for epp active
+# this file usually belongs in /etc/auto-ryzenadj.conf and uses TOML format
+# the example provided is my personal configuration for a GPD Win Max2 2023 with a AMD Ryzen™ 7 7840U.
+
+[main]
+# how many seconds to wait between each ryzenadj call
+timer = 5
+
+# the default profile
+# be sure that the profile exists
+default = "auto"
+
+# uncomment to set a custom ryzenadj executable path
+executable = "/usr/bin/ryzenadj"
+
+[logging]
+# uncomment to set a log file
+# %date% -> date in Year-Month-Day format
+# %time% -> time in Hour:Minute:Second format
+#file = "/var/log/auto-ryzenadj/auto-ryzenadj-%time%_%date%.log"
+# set logging level
+# 0 = off
+# 1 = info
+# 2 = warning
+# 3 = debug (WARNING THIS WILL SPAM THE LOG)
+level = 2
+
+# Example Profiles for a GPD Win Max2 2023 with a AMD Ryzen™ 7 7840U.
+[profiles]
+power = [
+    "--tctl-temp=65",
+    "--stapm-limit=6000",
+    "--fast-limit=8000",
+    "--slow-limit=6000"
+]
+
+powersave = [
+    "--tctl-temp=65",
+    "--stapm-limit=12000",
+    "--fast-limit=15000",
+    "--slow-limit=12000"
+]
+
+balance_power = [
+    "--tctl-temp=75",
+    "--stapm-limit=15000",
+    "--fast-limit=18000",
+    "--slow-limit=15000"
+]
+
+balance_performance = [
+    "--tctl-temp=75",
+    "--stapm-limit=22000",
+    "--fast-limit=24000",
+    "--slow-limit=22000"
+]
+
+performance = [
+    "--tctl-temp=85",
+    "--stapm-limit=28000",
+    "--fast-limit=28000",
+    "--slow-limit=28000"
+]
+
+extreme = [
+    "--tctl-temp=95",
+    "--stapm-limit=30000",
+    "--fast-limit=34000",
+    "--slow-limit=32000",
+]


### PR DESCRIPTION
When use auto profile, the actual profile read from `/sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference`(when epp is active) or `/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor`.
